### PR TITLE
Improve setJsonPayload to handle large payload and add improvement to handle xml responses

### DIFF
--- a/src/main/java/org/wso2/integration/connector/core/AbstractConnector.java
+++ b/src/main/java/org/wso2/integration/connector/core/AbstractConnector.java
@@ -18,8 +18,8 @@
 package org.wso2.integration.connector.core;
 
 import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import org.apache.axiom.om.OMElement;
 import org.apache.axis2.AxisFault;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseException;
@@ -29,6 +29,7 @@ import org.apache.synapse.core.axis2.Axis2MessageContext;
 import org.apache.synapse.data.connector.ConnectorResponse;
 import org.apache.synapse.data.connector.DefaultConnectorResponse;
 import org.apache.synapse.transport.passthru.PassThroughConstants;
+import org.wso2.integration.connector.core.exception.ContentBuilderException;
 import org.wso2.integration.connector.core.util.ConnectorUtils;
 import org.wso2.integration.connector.core.util.Constants;
 import org.wso2.integration.connector.core.util.PayloadUtils;
@@ -143,6 +144,21 @@ public abstract class AbstractConnector extends AbstractMediator implements Conn
         messageContext.setVariable(responseVariable, response);
     }
 
+    protected void handleConnectorResponse(MessageContext messageContext, String responseVariable,
+                                           Boolean overwriteBody, OMElement payload,
+                                           Map<String, Object> headers, Map<String, Object> attributes) {
+
+        ConnectorResponse response = new DefaultConnectorResponse();
+        if (overwriteBody != null && overwriteBody) {
+            overwriteXmlPayload(messageContext, payload);
+        } else {
+            response.setPayload(payload);
+        }
+        response.setHeaders(headers);
+        response.setAttributes(attributes);
+        messageContext.setVariable(responseVariable, response);
+    }
+
     private void overwritePayload(MessageContext messageContext, String payload) {
 
         org.apache.axis2.context.MessageContext axisMsgCtx =
@@ -154,6 +170,19 @@ public abstract class AbstractConnector extends AbstractMediator implements Conn
         }
         axisMsgCtx.setProperty(org.apache.axis2.Constants.Configuration.MESSAGE_TYPE, Constants.CONTENT_TYPE_JSON);
         axisMsgCtx.setProperty(org.apache.axis2.Constants.Configuration.CONTENT_TYPE, Constants.CONTENT_TYPE_JSON);
+        axisMsgCtx.removeProperty(PassThroughConstants.NO_ENTITY_BODY);
+    }
+
+    private void overwriteXmlPayload(MessageContext messageContext, OMElement payload) {
+
+        org.apache.axis2.context.MessageContext axisMsgCtx =
+                ((Axis2MessageContext) messageContext).getAxis2MessageContext();
+        try {
+            PayloadUtils.setPayloadInEnvelope(axisMsgCtx, payload);
+        } catch (ContentBuilderException e) {
+            handleException("Error overriding the message body with connector XML response.", e, messageContext);
+        }
+        PayloadUtils.handleSpecialProperties(PayloadUtils.APPLICATION_XML, axisMsgCtx);
         axisMsgCtx.removeProperty(PassThroughConstants.NO_ENTITY_BODY);
     }
 }

--- a/src/main/java/org/wso2/integration/connector/core/util/PayloadUtils.java
+++ b/src/main/java/org/wso2/integration/connector/core/util/PayloadUtils.java
@@ -17,14 +17,14 @@
  */
 package org.wso2.integration.connector.core.util;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.OMNode;
 import org.apache.axiom.om.OMFactory;
 import org.apache.axiom.om.OMNamespace;
 import org.apache.axiom.om.OMText;
 import org.apache.axiom.om.util.AXIOMUtil;
+import org.apache.axiom.soap.SOAPBody;
 import org.apache.axiom.soap.SOAPFactory;
 import org.apache.axis2.AxisFault;
 import org.apache.axis2.Constants;
@@ -41,6 +41,7 @@ import org.wso2.integration.connector.core.exception.ContentBuilderException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
 import java.util.Map;
 import javax.activation.DataHandler;
 import javax.xml.namespace.QName;
@@ -203,7 +204,20 @@ public final class PayloadUtils {
 
         try {
             String text = IOUtils.toString(inputStream, StandardCharsets.UTF_8.name());
-            JsonUtil.getNewJsonPayload(axis2MessageContext, text, true, true);
+            OMElement newElem = JsonUtil.getNewJsonPayload(axis2MessageContext, text, false, false);
+            // Avoid removeChildren=true in getNewJsonPayload to skip the recursive removeIndentations
+            // which might be an issue for larger payloads
+            // Instead, remove all existing body children directly here without tree traversal.
+            if (newElem != null) {
+                SOAPBody body = axis2MessageContext.getEnvelope().getBody();
+                Iterator children = body.getChildren();
+                while (children.hasNext()) {
+                    if (children.next() instanceof OMNode) {
+                        children.remove();
+                    }
+                }
+                body.addChild(newElem);
+            }
         } catch (IOException e) {
             throw new ContentBuilderException("Failed to set JSON content.", e);
         }

--- a/src/main/java/org/wso2/integration/connector/core/util/PayloadUtils.java
+++ b/src/main/java/org/wso2/integration/connector/core/util/PayloadUtils.java
@@ -210,11 +210,10 @@ public final class PayloadUtils {
             // Instead, remove all existing body children directly here without tree traversal.
             if (newElem != null) {
                 SOAPBody body = axis2MessageContext.getEnvelope().getBody();
-                Iterator children = body.getChildren();
+                Iterator<OMNode> children = body.getChildren();
                 while (children.hasNext()) {
-                    if (children.next() instanceof OMNode) {
-                        children.remove();
-                    }
+                    children.next();
+                    children.remove();
                 }
                 body.addChild(newElem);
             }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

This PR brings following two improvements.

- It improves setJsonPayload method to handle large payloads by manually removing the children in the envelope rather than relying on getNewJsonPayload.
- Also, it brings improvements to handle xml responses of connectors and store them as OMElement in the variable.